### PR TITLE
Use a zip file to replace lambda code

### DIFF
--- a/instructions/2-lambda-function.md
+++ b/instructions/2-lambda-function.md
@@ -44,9 +44,13 @@ In the [first step of this guide](./1-voice-user-interface.md), we built the Voi
 
 13. Scroll down the page until you see a section called **Function code**.
 
-11. **Open** this Lambda function [source code file](../lambda/custom/index.js), copy the contents of the file, and paste it into the index.js file found in the Lambda code editor.  Don't forget to Save.
+14. Upload this Lambda function [source code file](../lambda/custom). You can use the S3 link [https://s3-eu-west-1.amazonaws.com/skill-sample-nodejs-hello-world/lambda.zip
+](https://s3-eu-west-1.amazonaws.com/skill-sample-nodejs-hello-world/lambda.zip
+) to replace the lambda code. **Choose "Upload a file from Amazon S3"** and paste the URL in the text box. Alternatively you can build your own zip file and upload it by choosing "Upload a .zip file". Do not forget to run `npm install`, because the node_modules directory must be included in the zip file.
 
-13. You should see the Amazon Resource Name (ARN) a unique identifier for this function in the top right corner of the page. **Copy the ARN value for this Lambda function** for use in the next section of the guide.
+    ![Upload zip](https://s3-eu-west-1.amazonaws.com/skill-sample-nodejs-hello-world/upload-zip.png)
+
+15. You should see the Amazon Resource Name (ARN) a unique identifier for this function in the top right corner of the page. **Copy the ARN value for this Lambda function** for use in the next section of the guide.
 
     ![Copy ARN](https://m.media-amazon.com/images/G/01/mobile-apps/dex/alexa/alexa-skills-kit/tutorials/quiz-game/2-12-copy-ARN._TTH_.png)
 <!--TODO: THIS IMAGE NEEDS TO BE CUSTOMIZED FOR YOUR SKILL TEMPLATE. -->


### PR DESCRIPTION
The example lambda function `alexa-skills-kit-nodejs-factskill` is using other npm dependencies than the custom code. So when I was creating my first alexa skill (with the help of this awesome tutorial 😀), I needed to upload a complete zip file. 

*Issue #, if available:*

*Description of changes:*
I changed the step of just replacing the lambda code with using a zip file. For easy usage I've created a S3 bucket with the name `skill-sample-nodejs-hello-world` (if you want I can delete so that you can create the bucket with this name) and uploaded the zip file. I've also added the alternative step to build your own zip file. Once the zip file is uploaded the node_modules include the correct dependencies and the people can continue changing the code within the online editor. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.