### PR TITLE
Upgraded Nodejs skill templates from v8 to v10

### DIFF
--- a/ask-resources.json
+++ b/ask-resources.json
@@ -15,7 +15,7 @@
         },
         "skillInfrastructure": {
           "userConfig": {
-            "runtime": "nodejs8.10",
+            "runtime": "nodejs10.x",
             "handler": "index.handler"
           }
         }


### PR DESCRIPTION
*Description of changes:*

Since the Node.js 8.10 will soon be EOL, ASK SDK team upgraded the NodeJS skill templates to Node.js 10.x